### PR TITLE
add context to Launch and FactoryFunc

### DIFF
--- a/launcher/app.go
+++ b/launcher/app.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -12,7 +13,7 @@ type AppDef struct {
 	Description   string
 	RegisterFlags func(cmd *cobra.Command) error
 	InitFunc      func(runtime *Runtime) error
-	FactoryFunc   func(runtime *Runtime) (App, error)
+	FactoryFunc   func(ctx context.Context, runtime *Runtime) (App, error)
 }
 
 func (a *AppDef) String() string {

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -15,6 +15,7 @@
 package launcher
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -48,6 +49,7 @@ func NewLauncher(logger *zap.Logger, runtime *Runtime) *Launcher {
 		runtime:   runtime,
 		logger:    logger,
 	}
+
 	// TODO: this is weird should re-think this? Should the launcher be passed in every Factory App func instead?
 	// only the dashboard app that uses the launcher....
 	l.runtime.Launcher = l
@@ -58,7 +60,7 @@ func (l *Launcher) Close() {
 	l.shutter.Shutdown(nil)
 }
 
-func (l *Launcher) Launch(appNames []string) error {
+func (l *Launcher) Launch(ctx context.Context, appNames []string) error {
 	if len(appNames) == 0 {
 		return fmt.Errorf("no apps specified")
 	}
@@ -83,7 +85,7 @@ func (l *Launcher) Launch(appNames []string) error {
 
 		l.StoreAndStreamAppStatus(appID, AppStatusCreated)
 		l.logger.Debug("creating application", zap.String("app", appID))
-		app, err := appDef.FactoryFunc(l.runtime)
+		app, err := appDef.FactoryFunc(ctx, l.runtime)
 		if err != nil {
 			return fmt.Errorf("unable to create app %q: %w", appID, err)
 		}


### PR DESCRIPTION
why? 

because sometimes in the setup we want to do in the FactoryFunc, we would want to have a context available.